### PR TITLE
Implement bags using sets instead of lists; add set operations

### DIFF
--- a/test/test_bag.py
+++ b/test/test_bag.py
@@ -94,7 +94,7 @@ class Test_Bag(tcore.TCore):
         bag = self.table.filter('Estimates')
         another_bag = self.table.filter("WORLD")
 
-        union = bag + another_bag
+        union = bag | another_bag
         self.assertEqual(len(bag) + len(another_bag), len(union))
 
     def test_bag_set_difference(self):
@@ -123,9 +123,9 @@ class Test_Bag(tcore.TCore):
         col1 = self.table.filter("Index").fill(xypath.DOWN)
         col2 = self.table.filter("Variant").fill(xypath.DOWN)
 
-        bag = col1 + col2
+        bag = col1 | col2
 
-        self.assertEqual(["1", "Estimates", "2", "Estimates"],
+        self.assertEqual([1.0, "Estimates", 2.0, "Estimates"],
                          [cell.value for cell in list(bag)[:4]])
 
         def yx(cell):

--- a/test/test_xycell.py
+++ b/test/test_xycell.py
@@ -6,6 +6,19 @@ import unittest
 from copy import copy
 
 class XYCellTests(unittest.TestCase):
+
+    def test_cell_equality(self):
+        """
+        test_cell_equality: required for expected set behaviour
+        """
+        table = xypath.Table()
+
+        cell_a = xypath._XYCell("foo", 1, 3, table)
+        also_cell_a = xypath._XYCell("foo", 1, 3, table)
+
+        self.assertIsNot(cell_a, also_cell_a)
+        self.assertEqual(cell_a, also_cell_a)
+
     def test_cell_identity(self):
         """
         test_cell_identity: given two cells which were instantiated separately


### PR DESCRIPTION
[peter]
This is implemented in the course of working on the magic table scraper.

The change is needed so that we can add and subtract bags from one another, to have exclusions of cells from a bag.

Since the underlying data structure has no notion of ordering, we modify the iteration interface so that iteration occurs in the "intuitive" way, i.e, left-right, top-bottom.

Lots of tests added.

We'll be merging when it goes green on travis.
