### PR TITLE
Apply filter() lambda to the cell, rather than the bag

### DIFF
--- a/xypath/xypath.py
+++ b/xypath/xypath.py
@@ -138,6 +138,9 @@ class _XYCell(object):
         other_bag.add(other)
         yield (self_bag, other_bag, junction_bag)
 
+    def shift(self, x, y):
+        return self.table.get_at(self.x + x, self.y + y)._cell
+
 
 class CoreBag(object):
     """Has a collection of _XYCells"""
@@ -234,9 +237,9 @@ class CoreBag(object):
 
     def _filter_internal(self, function):
         newbag = Bag(table=self.table)
-        for bag_cell in self:
+        for bag_cell in self.unordered_cells:
             if function(bag_cell):
-                newbag.add(bag_cell._cell)
+                newbag.add(bag_cell)
         return newbag
 
     def assert_one(self, message="assert_one() : {} cells in bag, not 1"):


### PR DESCRIPTION
This change eliminates 90% of the runtime of the `filter()` call by
removing the need to construct a singleton bag for every XYCell.

This improvement is fairly large since this is where 50% of the time
of our tests was spent, and `filter()` is one of the most common operations
one wants to do.

I've put this in a separate pull request because the change may be controversial
and/or break code in the wild which depends on `filter(lambda bag: [...])` as
opposed to `filter(lambda cell: [...])`. However, I can't think of any reasonable
thing one might want to do which requires bag operations other than `shift()`,
so I've added `shift()` to the `_XYCell` class.

@dragon? @paulfurley?
