### PR TITLE
tests: Memoize fixture loading (so that it doesn't happen once per suite)

### DIFF
--- a/test/tcore.py
+++ b/test/tcore.py
@@ -3,9 +3,11 @@ import sys
 import unittest
 sys.path.append('xypath')
 import xypath
-import messytables
-from os.path import dirname, abspath, join, splitext
 
+import messytables
+from os.path import dirname, abspath, join as pjoin, splitext
+
+FIXTURE_DIR = pjoin(abspath(dirname(__file__)), '..', 'fixtures')
 
 def get_extension(filename):
     """
@@ -14,14 +16,27 @@ def get_extension(filename):
     """
     return splitext(filename)[1].strip('.')
 
+def get_fixture_filename(name):
+    return pjoin(FIXTURE_DIR, name)
+
+def get_messytables_fixture(name, table_index=0, memoized={}):
+    """
+    Memoized function for loading fixtures
+    """
+    
+    if name not in memoized:
+        with open(name, "rb") as fd:
+            messy = messytables.any.any_tableset(fd)
+            messytable = messy.tables[table_index]
+        memoized[name] = (messy, xypath.Table.from_messy(messytable))
+
+    return memoized[name]
 
 class TCore(unittest.TestCase):
     @classmethod
     def setup_class(cls):
-        cls.wpp_filename = join(
-            abspath(dirname(__file__)), '..', 'fixtures', 'wpp.xls')
-        cls.messy = messytables.excel.XLSTableSet(open(cls.wpp_filename, "rb"))
-        cls.table = xypath.Table.from_messy(cls.messy.tables[0])
+        cls.wpp_filename = get_fixture_filename("wpp.xls")
+        cls.messy, cls.table = get_messytables_fixture(cls.wpp_filename)
 
     def setUp(self):
         pass
@@ -29,10 +44,8 @@ class TCore(unittest.TestCase):
 class TMissing(unittest.TestCase):
     @classmethod
     def setup_class(cls):
-        cls.wpp_filename = join(
-            abspath(dirname(__file__)), '..', 'fixtures', 'missingcell.csv')
-        cls.messy = messytables.commas.CSVTableSet(open(cls.wpp_filename, "rb"))
-        cls.table = xypath.Table.from_messy(cls.messy.tables[0])
+        cls.wpp_filename = get_fixture_filename("missingcell.csv")
+        cls.messy, cls.table = get_messytables_fixture(cls.wpp_filename)
 
     def setUp(self):
         pass


### PR DESCRIPTION
Before this PR, test run time is dominated by loading data, once per `test_*` file. This change makes a `get_fixture` function which memoizes the tables so that they are re-used.

On top of the other pull requests, it represents another -1/3 on the time run time.
