### PR TITLE
Use same version of messytables as in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     include_package_data=False,
     zip_safe=False,
     install_requires=[
-        'messytables>=0.14.5',
+        'messytables==0.15',
     ],
     tests_require=[],
     entry_points=\


### PR DESCRIPTION
Also pin the version too as it is in requirements.txt.

Should have been part of #78.

Discovered this because Travis tests were failing as they were using the
wrong version of messytables.