### PR TITLE
Handle pattern type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install setuptools --upgrade # fix for html5lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install setuptools --upgrade # fix for html5lib

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ navigating around and extracting values from tabular data.
 
 setup(
     name='xypath',
-    version='1.1.0',
+    version='1.1.1',
     description="Extract fields from tabular data with complex expressions.",
     long_description=long_desc,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     keywords='',
     author='The Sensible Code Company Ltd',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
     ],
     keywords='',
     author='The Sensible Code Company Ltd',

--- a/xypath/xypath.py
+++ b/xypath/xypath.py
@@ -22,7 +22,7 @@ except ImportError:
 import sys
 if sys.version_info >= (3, 6):
     import typing
-    REGEX_PATTERN_TYPE = typing.re.Pattern
+    REGEX_PATTERN_TYPE = typing.Pattern
 else:
     REGEX_PATTERN_TYPE = re._pattern_type
 

--- a/xypath/xypath.py
+++ b/xypath/xypath.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     have_ham = False
 
+import sys
+if sys.version_info >= (3, 6):
+    import typing
+    re._pattern_type = typing.re.Pattern
+
 from collections import defaultdict
 from copy import copy
 from itertools import product, takewhile

--- a/xypath/xypath.py
+++ b/xypath/xypath.py
@@ -22,7 +22,9 @@ except ImportError:
 import sys
 if sys.version_info >= (3, 6):
     import typing
-    re._pattern_type = typing.re.Pattern
+    REGEX_PATTERN_TYPE = typing.re.Pattern
+else:
+    REGEX_PATTERN_TYPE = re._pattern_type
 
 from collections import defaultdict
 from copy import copy
@@ -81,7 +83,7 @@ def describe_filter_method(filter_by):
             return "containing the string {!r}".format(filter_by)
         if have_ham and isinstance(filter_by, hamcrest.matcher.Matcher):
             return "containing "+str(filter_by)
-        if isinstance(filter_by, re._pattern_type):
+        if isinstance(filter_by, REGEX_PATTERN_TYPE):
             return "matching the regex {!r}".format(filter_by.pattern)
         else:
             return "which we're surprised we found at all"
@@ -408,7 +410,7 @@ class CoreBag(object):
             return self._filter_internal(lambda cell: six.text_type(cell.value).strip() == filter_by)
         elif have_ham and isinstance(filter_by, hamcrest.matcher.Matcher):
             return self._filter_internal(lambda cell: filter_by.matches(cell.value))
-        elif isinstance(filter_by, re._pattern_type):
+        elif isinstance(filter_by, REGEX_PATTERN_TYPE):
             return self._filter_internal(
                 lambda cell: re.match(filter_by, six.text_type(cell.value)))
         else:


### PR DESCRIPTION
Fixes #86.

In newer Pythons, `re._pattern_type` is removed.

Use the equivalent feature in Python 3.6 and up: `typing.Pattern`.

Python 3.5 doesn't allows the use of `Pattern` as a [direct substitute](https://stackoverflow.com/a/34178375).

NB: Travis currently [doesn't support Python 3.7](https://github.com/travis-ci/travis-ci/issues/9815), so don't add that yet.