### PR TITLE
Remove Travis build status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 Select different parts of a spreadsheet via functions.
 
-[![Build Status](https://travis-ci.org/sensiblecodeio/xypath.png?branch=master)](https://travis-ci.org/sensiblecodeio/xypath)
-
-
 ```
 ----------------------------------------------------------------------
 | animal  | habitat    | max age | population 2012 | Population 2013 |


### PR DESCRIPTION
Can see build status on master with GitHub Actions without including in
README.